### PR TITLE
fix for make status output to be portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 MFILECWD = $(shell pwd)
 
+# sed 1-liner to reverse the lines in an input stream
+REVERSE_LINES=sed -e '1!G;h;$$!d'
+
 # === BEGIN USER OPTIONS ===
 # Box setup
 BOX_IMAGE ?= centos/7
@@ -129,16 +132,16 @@ status: status-master $(shell for i in $(shell seq 1 $(NODE_COUNT)); do echo "st
 status-master: ## Show status of the master VM.
 	@STATUS_OUT="$$(vagrant status | tail -n+3)"; \
 		if (( $$(echo "$$STATUS_OUT" | wc -l) > 5 )); then \
-			echo "$$STATUS_OUT" | head -n-5; \
+			echo "$$STATUS_OUT" | $(REVERSE_LINES) | tail -n +6 | $(REVERSE_LINES); \
 		else \
-			echo "$$STATUS_OUT" | head -n-2; \
+			echo "$$STATUS_OUT" | $(REVERSE_LINES) | tail -n +3 | $(REVERSE_LINES); \
 		fi
 status-node-%: ## Show status of a node VM, where `%` is the number of the node.
 	@STATUS_OUT="$$(VAGRANT_VAGRANTFILE=Vagrantfile_nodes NODE=$* vagrant status | tail -n+3)"; \
 		if (( $$(echo "$$STATUS_OUT" | wc -l) > 5 )); then \
-			echo "$$STATUS_OUT" | head -n-5; \
+			echo "$$STATUS_OUT" | $(REVERSE_LINES) | tail -n +6 | $(REVERSE_LINES); \
 		else \
-			echo "$$STATUS_OUT" | head -n-2; \
+			echo "$$STATUS_OUT" | $(REVERSE_LINES) | tail -n +3 | $(REVERSE_LINES); \
 		fi
 
 status-nodes: $(shell for i in $(shell seq 1 $(NODE_COUNT)); do echo "status-node-$$i"; done) ## Show status of all node VMs.


### PR DESCRIPTION
Resolves issue #4 

Before the fix on Mac I would see:
```console
> make status
head: illegal line count -- -5
make: *** [status-master] Error 1
```

Now after this fix, I see:
```console
> make status
master                    running (virtualbox)
node1                     running (virtualbox)
node2                     running (virtualbox)
```