### PR TITLE
pass KUBEADM_JOIN_FLAGS only when non-zero length

### DIFF
--- a/Vagrantfile_nodes
+++ b/Vagrantfile_nodes
@@ -53,10 +53,20 @@ $kubeMinionScript = <<SCRIPT
 
 set -x
 kubeadm reset
-kubeadm join \
-    #{KUBEADM_JOIN_FLAGS} \
-    --discovery-token-unsafe-skip-ca-verification \
-    --token "#{KUBETOKEN}" "#{MASTER_IP}:6443"
+
+if [ -n "#{KUBEADM_JOIN_FLAGS}" ]; then
+    kubeadm join \
+        #{KUBEADM_JOIN_FLAGS} \
+        --discovery-token-unsafe-skip-ca-verification \
+        --token "#{KUBETOKEN}" \
+        "#{MASTER_IP}:6443"
+else
+    kubeadm join \
+        --discovery-token-unsafe-skip-ca-verification \
+        --token "#{KUBETOKEN}" \
+        "#{MASTER_IP}:6443"
+fi
+
 grep -q -- '--node-ip=' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf && \
     sed -ri -e 's/KUBELET_NETWORK_ARGS=--node-ip=[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ /KUBELET_NETWORK_ARGS=/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 sed -i 's/KUBELET_NETWORK_ARGS=/KUBELET_NETWORK_ARGS=--node-ip=#{NODE_IP} /' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf


### PR DESCRIPTION
Resolves #11 

Passing `#{KUBEADM_JOIN_FLAGS}` from ruby when it's empty results in `''` string in the bash script which is then incorrectly interpreted as the master IP address by the `kubeadm join` command.  Not passing `#{KUBEADM_JOIN_FLAGS}` at all when it's empty fixes this, but there may be a better solution.  Just wanted to share what seems to have worked for me.