### PR TITLE
Fix ipvs config file name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables
 systemctl stop firewalld && systemctl disable firewalld && systemctl mask firewalld
 
 if [ "#{KUBE_PROXY_IPVS}" != "false" ]; then
-    cat << EOF > /etc/modules-load.d/ipvs
+    cat << EOF > /etc/modules-load.d/ipvs.conf
 ip_vs_sh
 nf_conntrack_ipv4
 ip_vs

--- a/Vagrantfile_nodes
+++ b/Vagrantfile_nodes
@@ -54,7 +54,7 @@ echo '1' > /proc/sys/net/bridge/bridge-nf-call-iptables
 systemctl stop firewalld && systemctl disable firewalld && systemctl mask firewalld
 
 if [ "#{KUBE_PROXY_IPVS}" != "false" ]; then
-    cat << EOF > /etc/modules-load.d/ipvs
+    cat << EOF > /etc/modules-load.d/ipvs.conf
 ip_vs_sh
 nf_conntrack_ipv4
 ip_vs


### PR DESCRIPTION
Files in /etc/modules.d/ should have *.conf name according to systemd-modules-load.service documentation. Without .conf ipvs modules don't load at statup