### PR TITLE
Use kubeadm reset force flag

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,7 @@ SCRIPT
 $kubeMasterScript = <<SCRIPT
 
 set -x
-kubeadm reset
+kubeadm reset -f
 kubeadm init #{KUBEADM_INIT_FLAGS} \
     --apiserver-advertise-address=#{MASTER_IP} \
     --pod-network-cidr=#{POD_NW_CIDR} \

--- a/Vagrantfile_nodes
+++ b/Vagrantfile_nodes
@@ -68,7 +68,7 @@ SCRIPT
 $kubeMinionScript = <<SCRIPT
 
 set -x
-kubeadm reset
+kubeadm reset -f
 
 if [ -n "#{KUBEADM_JOIN_FLAGS}" ]; then
     kubeadm join \


### PR DESCRIPTION
This prevents the cluster from starting up with current K8S versions (1.12>= it seems).
Otherwise the startup fails with `kubeadm reset` waiting for interactive response.