### PR TITLE
DNM: libvirt working with centos/7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REVERSE_LINES=sed -e '1!G;h;$$!d'
 
 # === BEGIN USER OPTIONS ===
 # Vagrantfile set to use.
-BOX_OS ?= fedora
+BOX_OS ?= centos
 # Box setup
 #BOX_IMAGE
 # Disk setup
@@ -126,7 +126,7 @@ pull: ## Add and download, or update the box image on the host.
 		vagrant \
 			box \
 			add \
-			--provider=virtualbox \
+			--provider=libvirt \
 			$(shell grep "^\$$box_image.*=.*'.*'\.freeze" "$(MFILECWD)/vagrantfiles/$(BOX_OS)/common" | cut -d\' -f2); \
 	else \
 		vagrant box update --box=$(shell grep "^\$$box_image.*=.*'.*'\.freeze" "$(MFILECWD)/vagrantfiles/$(BOX_OS)/common" | cut -d\' -f2); \

--- a/vagrantfiles/Vagrantfile_master
+++ b/vagrantfiles/Vagrantfile_master
@@ -9,15 +9,25 @@ Vagrant.configure('2') do |config|
         l.memory = MASTER_MEMORY_SIZE_GB * 1024
     end
 
+    config.vm.provider 'libvirt' do |lv|
+        lv.cpus = MASTER_CPUS
+        lv.memory = MASTER_MEMORY_SIZE_GB * 1024
+    end
+
     config.vm.define 'master' do |subconfig|
         subconfig.vm.hostname = 'master'
         subconfig.vm.network :private_network, ip: MASTER_IP
-        subconfig.vm.provider :virtualbox do |vb|
-            vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
-            # Network configuration
-            vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
-            # Storage configuration is done after provision in Makefile
-            # This is because Vagrant is only once reading the Vagrantfile
+        #subconfig.vm.provider :virtualbox do |vb|
+        #    vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
+        #    # Network configuration
+        #    vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+        #    # Storage configuration is done after provision in Makefile
+        #    # This is because Vagrant is only once reading the Vagrantfile
+        #end
+        subconfig.vm.provider :libvirt do |lv|
+            (1..DISK_COUNT.to_i).each do |diskID|
+                lv.storage :file, :size => "#{DISK_SIZE_GB}G"
+            end
         end
         subconfig.vm.synced_folder "data/#{BOX_OS}-master/", '/data', type: 'rsync',
             create: true, owner: 'root', group: 'root',
@@ -29,7 +39,7 @@ Vagrant.configure('2') do |config|
         subconfig.vm.provision :shell, inline: $prepareScript
         subconfig.vm.provision :shell, inline: $baseInstallScript
         subconfig.vm.provision :shell, inline: $verifyNodeScript
-        subconfig.vm.provision :diskandreboot
+        #subconfig.vm.provision :diskandreboot
         subconfig.vm.provision :shell, inline: $kubeMasterScript
         # Addons
         if K8S_DASHBOARD.to_s == 'true'

--- a/vagrantfiles/Vagrantfile_node
+++ b/vagrantfiles/Vagrantfile_node
@@ -9,15 +9,25 @@ Vagrant.configure('2') do |config|
         l.memory = NODE_MEMORY_SIZE_GB * 1024
     end
 
+    config.vm.provider 'libvirt' do |lv|
+        lv.cpus = NODE_CPUS
+        lv.memory = NODE_MEMORY_SIZE_GB * 1024
+    end
+
     config.vm.define "node#{NODE}" do |subconfig|
         subconfig.vm.hostname = "node#{NODE}"
         subconfig.vm.network :private_network, ip: NODE_IP
-        subconfig.vm.provider :virtualbox do |vb|
-            vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
-            # Network configuration
-            vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-            # Storage configuration is done after provision in Makefile
-            # This is because Vagrant is only once reading the Vagrantfile
+        #subconfig.vm.provider :virtualbox do |vb|
+        #    vb.customize ['modifyvm', :id, '--uartmode1', 'disconnected']
+        #    # Network configuration
+        #    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        #    # Storage configuration is done after provision in Makefile
+        #    # This is because Vagrant is only once reading the Vagrantfile
+        #end
+        subconfig.vm.provider :libvirt do |lv|
+            (1..DISK_COUNT.to_i).each do |diskID|
+                lv.storage :file, :size => "#{DISK_SIZE_GB}G"
+            end
         end
         subconfig.vm.synced_folder "data/#{BOX_OS}-node#{NODE}/", '/data', type: 'rsync',
             create: true, owner: 'root', group: 'root',
@@ -29,7 +39,7 @@ Vagrant.configure('2') do |config|
         subconfig.vm.provision :shell, inline: $prepareScript
         subconfig.vm.provision :shell, inline: $baseInstallScript
         subconfig.vm.provision :shell, inline: $verifyNodeScript
-        subconfig.vm.provision :diskandreboot
+        #subconfig.vm.provision :diskandreboot
         subconfig.vm.provision :shell, inline: $kubeMinionScript
     end
 end

--- a/vagrantfiles/centos/common
+++ b/vagrantfiles/centos/common
@@ -1,1 +1,1 @@
-$box_image = ENV["BOX_IMAGE"] || 'generic/centos7'.freeze
+$box_image = ENV["BOX_IMAGE"] || 'centos/7'.freeze


### PR DESCRIPTION
this patch got things working with libvirt on centos/7. it needs to be to be cleaned up and generalized a bit to play nice with virtualbox.

things of note: private networking didn't work with fedora guests. it just hung waiting for IP assignments. it also didn't work with the `generic/centos7` box, but it did with the `centos/7` box.

PROOOOF

```
[nwatkins@smash k8s-vagrant-multi-node]$ kubectl get nodes                                                                                                                                                                                                                                
NAME     STATUS   ROLES    AGE     VERSION                                                                                                                                                                                                                                                
master   Ready    master   5m26s   v1.13.3                                                                                                                                                                                                                                                
node1    Ready    <none>   3m58s   v1.13.3                                                                                                                                                                                                                                                
node2    Ready    <none>   2m20s   v1.13.3                                                                                                                                                                                                                                                
[nwatkins@smash k8s-vagrant-multi-node]$ make ssh-node-1                                                                                                                                                                                                                                  
NODE=1 vagrant ssh                                                                                                                                                                                                                                                                        
[vagrant@node1 ~]$ lsblk                                                                                                                                                                                                                                                                  
NAME   MAJ:MIN RM SIZE RO TYPE MOUNTPOINT                                                                                                                                                                                                                                                 
vda    253:0    0  41G  0 disk                                                                                                                                                                                                                                                            
└─vda1 253:1    0  40G  0 part /                                                                                                                                                                                                                                                          
vdb    253:16   0   7G  0 disk                                                                                                                                                                                                                                                            
vdc    253:32   0   7G  0 disk                                                  
```