### PR TITLE
Add Calico CNI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ versions                       Print the "imporant" tools versions out for easie
 | `KUBERNETES_VERSION`            | `""` (empty)             | The `kubeadm` and `kubelet` package and API server version to install (`KUBEADM_INIT_FLAGS` will be set to `--kubernetes-version=$KUBERNETES_VERSION` if unset). |
 | `KUBERNETES_PKG_VERSION_SUFFIX` | `""` (empty)             | String which will be appended to the `kubeadm` and `kubelet` package versions when installed (only used for `vagrantfiles/ubuntu`).                              |
 | `KUBE_PROXY_IPVS`               | `false`                  | Enable IPVS kernel modules to then use IPVS for the kube-proxy.                                                                                                  |
-| `KUBE_NETWORK`                  | `flannel`                | What CNI to install, if empty don't install any CNI. `flannel` and `canal` are supported options.                                                                |
+| `KUBE_NETWORK`                  | `flannel`                | What CNI to install, if empty don't install any CNI. `flannel`, `canal` and `calico` are supported options.                                                                |
 | `KUBECTL_AUTO_CONF`             | `true`                   | If `kubectl` should be  automatically configured to be able to talk with the cluster (if disabled, removes need for `kubectl` binary).                           |
 
 ## Demo

--- a/vagrantfiles/Vagrantfile_common
+++ b/vagrantfiles/Vagrantfile_common
@@ -147,6 +147,12 @@ case "#{$kube_network}" in
         sed -e 's/canal_iface:.*/canal_iface: "eth1"/' | \
         kubectl apply -f -
   ;;
+# Calico network: https://docs.projectcalico.org/v3.8/getting-started/kubernetes/installation/calico
+[Cc][Aa][Ll][Ii][Cc][Oo])
+    curl --retry 5 --fail -s https://docs.projectcalico.org/v3.8/manifests/calico.yaml | \
+        sed -e "s?192.168.0.0/16?${POD_NW_CIDR}?g" | \
+        kubectl apply -f -
+  ;;
 # flannel network
 *)
     curl --retry 5 --fail -s https://github.com/coreos/flannel/blob/v0.11.0/Documentation/kube-flannel.yml | \


### PR DESCRIPTION
(cherry picked from commit 43d42a6678c8388e2edb54bbe9074f076a1e5025)

Thanks to @AloysAugustin for implementing this in his fork! :wink:

This adds Calico 3.8 CNI as a CNI network option.