### PR TITLE
vagrant: updated fedora box to version 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ List of currently available Vagrantfile sets:
 | Name     | Container Runtime                           | OS Version   | Special Notes                                                                                                                           |
 | -------- | ------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `centos` | [Docker/Moby](https://github.com/moby/moby) | CentOS 7     | N/A                                                                                                                                     |
-| `fedora` | [Docker/Moby](https://github.com/moby/moby) | Fedora 29    | N/A                                                                                                                                     |
+| `fedora` | [Docker/Moby](https://github.com/moby/moby) | Fedora 30    | N/A                                                                                                                                     |
 | `ubuntu` | [Docker/Moby](https://github.com/moby/moby) | Ubuntu 18.04 | `canal` is used here due to issues with Ubuntu. Google DNS Servers are used due to resolution issues with the ubuntu Vagrant Box image. |
 
 To use a different set than the default `fedora` one's, add `BOX_OS=__NAME__` (where `__NAME__` is, e.g., `fedora`).

--- a/vagrantfiles/fedora/common
+++ b/vagrantfiles/fedora/common
@@ -1,4 +1,4 @@
-$box_image = ENV['BOX_IMAGE'] || 'generic/fedora29'.freeze
+$box_image = ENV['BOX_IMAGE'] || 'generic/fedora30'.freeze
 
 $osPrepareScript = <<SCRIPT
 set -x
@@ -6,4 +6,7 @@ set -x
 systemctl stop firewalld
 systemctl disable firewalld
 systemctl mask firewalld
+
+update-alternatives --set iptables /usr/sbin/iptables-legacy
+
 SCRIPT

--- a/vagrantfiles/ubuntu/pre
+++ b/vagrantfiles/ubuntu/pre
@@ -2,4 +2,10 @@ $kube_network = 'canal'
 
 $osPrepareScript = <<SCRIPT
 sed -i 's/^DNS=.*/DNS=8.8.8.8 8.8.4.4/' /etc/systemd/resolved.conf
+
+sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+sudo update-alternatives --set arptables /usr/sbin/arptables-legacy
+sudo update-alternatives --set ebtables /usr/sbin/ebtables-legacy
+
 SCRIPT


### PR DESCRIPTION
An update to Fedora 31 is possible but right now "too much" to add in the bit
of time I have to update the project right now.

In Fedora 31 Docker doesn't work out of the box right now due to cgroups
v2 being set to unified, see
https://bugzilla.redhat.com/show_bug.cgi?id=1746355 for more
information.

Add the update-alternatives for iptables which is needed as described
here: https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/#ensure-iptables-tooling-does-not-use-the-nftables-backend

Signed-off-by: Alexander Trost <galexrt@googlemail.com>