### PR TITLE
Fix to os prepare script be applied

### DIFF
--- a/vagrantfiles/Vagrantfile_vars
+++ b/vagrantfiles/Vagrantfile_vars
@@ -60,7 +60,9 @@ $storagecontroller = 'k8svmSATAController'
 $storagecontrollerneedstobecreated = true
 
 # Common scripts
-$osPrepareScript = ""
+if $osPrepareScript.nil? || $osPrepareScript == ""
+   $osPrepareScript = ""
+end
 
 $prepareScript = <<SCRIPT
 set -x


### PR DESCRIPTION
Hi, Thanks for providing such a nice project. I've been using this project for provisioning multi-node-k8s-cluster easily.

However, I found some issues when dealing with ubuntu-os.
And I thought the problem was occured since the file-loading-order is as followings in Vagrantfile,
```
$osprefile = File.expand_path("../#{BOX_OS}/pre", __FILE__)
load $osprefile if File.exist?($osprefile)

# Load the Vagrantfile_vars file
$vagrantfilecommon = File.expand_path('../Vagrantfile_vars', __FILE__)
load $vagrantfilecommon
```

Even if the os was ubuntu, the value `$osPrepareScript` in `vagrantfiles/ubuntu/pre` file was overwriten to be `""` by loading `$vagrantfilecommon`.

So the `$osPrepareScript` was not executed as expected.