### PR TITLE
Update fedora to 32

### DIFF
--- a/vagrantfiles/Vagrantfile
+++ b/vagrantfiles/Vagrantfile
@@ -103,6 +103,11 @@ Vagrant.configure('2') do |config|
         # Run diskandreboot plugin to add VirtualBox disks to VMs
         if VAGRANT_DEFAULT_PROVIDER == 'virtualbox'
             subconfig.vm.provision :diskandreboot
+        else
+            # Due to Docker still using non-unified cgroups, a reboot is needed
+            if BOX_OS == 'fedora'
+                subconfig.vm.provision :reload
+            end
         end
         # Node Provision
         if $hostname.include? "node"

--- a/vagrantfiles/Vagrantfile_scripts
+++ b/vagrantfiles/Vagrantfile_scripts
@@ -32,7 +32,7 @@ EOF
 # Set mtu of eth0 and eth1 devices to 1300, otherwise there may be issues when using a VPN on the host system.
 cat <<EOF > /etc/systemd/system/ip-set-mtu.service
 [Unit]
-After=network.target
+After=network-online.target
 [Service]
 Type=oneshot
 ExecStart=/bin/bash -c 'ip link set mtu 1300 dev eth0'

--- a/vagrantfiles/fedora/common
+++ b/vagrantfiles/fedora/common
@@ -39,11 +39,13 @@ set -x
 
 retries=5
 for ((i=1; i<retries; i++)); do
-    dnf -y install dnf-plugins-core
+    dnf -y install dnf-plugins-core grubby
     dnf config-manager \
         --add-repo \
         https://download.docker.com/linux/fedora/docker-ce.repo
     sed -i 's/$releasever/31/g' /etc/yum.repos.d/docker-ce.repo
+    grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
+
     dnf -y install docker-ce docker-ce-cli containerd.io && \
         break
 

--- a/vagrantfiles/fedora/common
+++ b/vagrantfiles/fedora/common
@@ -1,4 +1,4 @@
-$box_image = ENV['BOX_IMAGE'].to_s.strip.empty? ? 'fedora/30-cloud-base'.freeze : ENV['BOX_IMAGE']
+$box_image = ENV['BOX_IMAGE'].to_s.strip.empty? ? 'fedora/32-cloud-base'.freeze : ENV['BOX_IMAGE']
 
 # Use iptables-legacy for iptables
 $osPrepareScript = <<SCRIPT
@@ -43,7 +43,8 @@ for ((i=1; i<retries; i++)); do
     dnf config-manager \
         --add-repo \
         https://download.docker.com/linux/fedora/docker-ce.repo
-    dnf install -y docker-ce docker-ce-cli containerd.io && \
+    sed -i 's/$releasever/31/g' /etc/yum.repos.d/docker-ce.repo
+    dnf -y install docker-ce docker-ce-cli containerd.io && \
         break
 
     [[ $retries -eq i ]] && { echo "Failed to install docker-ce after 5 tries"; exit 1; }


### PR DESCRIPTION
This updates Fedora to release 32 and "fixes" Docker by setting the unified cgroups kernel arg.