### PR TITLE
Update Centos version for vagrant box

### DIFF
--- a/vagrantfiles/centos8/common
+++ b/vagrantfiles/centos8/common
@@ -1,4 +1,4 @@
-$box_image = ENV['BOX_IMAGE'].to_s.strip.empty? ? 'centos/7'.freeze : ENV['BOX_IMAGE']
+$box_image = ENV['BOX_IMAGE'].to_s.strip.empty? ? 'centos/8'.freeze : ENV['BOX_IMAGE']
 
 # Stop and disable firewalld service
 $osPrepareScript = <<SCRIPT


### PR DESCRIPTION
The centos version should be 8 for centos8 box os.

Signed-off-by: Yug Gupta <ygupta@redhat.com>

Updates: #73 