### PR TITLE
Documentation discrepancy: fix default mem size for nodes.

### DIFF
--- a/vagrantfiles/Vagrantfile_vars
+++ b/vagrantfiles/Vagrantfile_vars
@@ -10,7 +10,7 @@ DISK_SIZE_GB = ENV['DISK_SIZE_GB'].to_s.strip.empty? ? 20 : ENV['DISK_SIZE_GB'].
 MASTER_CPUS = ENV['MASTER_CPUS'].to_s.strip.empty? ? 2 : ENV['MASTER_CPUS'].to_i
 MASTER_MEMORY_SIZE_GB = ENV['MASTER_MEMORY_SIZE_GB'].to_s.strip.empty? ? 2 : ENV['MASTER_MEMORY_SIZE_GB'].to_i
 NODE_CPUS = ENV['NODE_CPUS'].to_s.strip.empty? ? 1 : ENV['NODE_CPUS'].to_i
-NODE_MEMORY_SIZE_GB = ENV['NODE_MEMORY_SIZE_GB'].to_s.strip.empty? ? 1 : ENV['NODE_MEMORY_SIZE_GB'].to_i
+NODE_MEMORY_SIZE_GB = ENV['NODE_MEMORY_SIZE_GB'].to_s.strip.empty? ? 2 : ENV['NODE_MEMORY_SIZE_GB'].to_i
 
 # BOX_OS specific fixes
 ## Currently only used by ubuntu


### PR DESCRIPTION
In README, it is stated that node memory is 2 GB by default - but it's not. This PR fixes the code so it actually is 2 GB.