### PR TITLE
Use /usr/bin/env bash in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Bash is required as the shell
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 
 # Set Makefile directory in variable for referencing other files
 MFILECWD = $(dir $(realpath $(firstword $(MAKEFILE_LIST))))


### PR DESCRIPTION
Do not force the use of /bin/bash for the Makefile. Instead look
for the bash version used by the session. On MacOS, the system
ships with a very old version of bash, and users often download
a newer version that resides elsewhere on the system.

Signed-off-by: Blaine Gardner <b.blaine.gardner@gmail.com>