### PR TITLE
Add lvm2 package to fedora

### DIFF
--- a/vagrantfiles/fedora/common
+++ b/vagrantfiles/fedora/common
@@ -46,7 +46,7 @@ set -x
 
 retries=5
 for ((i=1; i<retries; i++)); do
-    dnf -y install dnf-plugins-core grubby
+    dnf -y install lvm2 dnf-plugins-core grubby
     dnf config-manager \
         --add-repo \
         https://download.docker.com/linux/fedora/docker-ce.repo


### PR DESCRIPTION
The lvm2 package is still needed by some Rook configs including
the cluster-test.yaml.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>